### PR TITLE
DWPS-42 Color Settings

### DIFF
--- a/wp-content/themes/devoted/theme.json
+++ b/wp-content/themes/devoted/theme.json
@@ -233,6 +233,24 @@
                     "slug": "secondary-base-to-darker",
                     "gradient": "linear-gradient(to bottom right, var(--wp--preset--color--secondary-base),var(--wp--preset--color--secondary-darker))"
                 }
+            ],
+            "duotone": [
+                {
+                    "name": "Primary Secondary",
+                    "slug": "primary-secondary",
+                    "colors": [
+                        "#88D6B3",
+                        "#9E589E"
+                    ]
+                },
+                {
+                    "name": "Secondary Tertiary",
+                    "slug": "secondary-tertiary",
+                    "colors": [
+                        "#9E589E",
+                        "#FFAE57"
+                    ]
+                }
             ]
         },
         "typography": {


### PR DESCRIPTION
## Description

Configures the following color-related settings:

- Adjusts the color palette (different, possibly better color values)
- Adds a scaffold for tertiary colors
- Removes the status colors from the color palette and sets them as custom vars (editors do not need these colors)
- Defines starter gradients
- Defines starter duotones
- Disables WP default palettes for gradients & duotones
- Disables custom gradients & duotones

## Motivation / Context

Closes:

- #42 
- #26 
- #16 
- #17 

## Testing Instructions

In the Tugboat preview, verify that:

- [x] Colors are updated to new palette
- [x] Status colors are not available in the color chooser
- [x] Custom gradients are not allowed, and no WP gradient presets appear in the gradient chooser
- [x] Custom duotones are not allowed, and no WP duotones appear in the duotones pane (select an image block to view)

## Screenshots

### Updated color palette with tertiary colors, no status colors

| Before | After |
|---|---|
| <img width="250" height="422" alt="Screenshot 2026-02-01 at 4 18 50 PM" src="https://github.com/user-attachments/assets/09ea34c8-90ff-4f3c-ae89-17c084e601c3" /> | <img width="252" height="441" alt="Screenshot 2026-02-01 at 4 18 17 PM" src="https://github.com/user-attachments/assets/141dcbad-987a-44fb-862c-c942aeaa1246" /> |

### Gradients chooser

| Before | After |
|---|---|
| <img width="262" height="338" alt="Screenshot 2026-02-01 at 6 23 54 PM" src="https://github.com/user-attachments/assets/e97ea884-3342-4999-82af-d6a18879d53a" /> | <img width="256" height="138" alt="Screenshot 2026-02-01 at 6 24 14 PM" src="https://github.com/user-attachments/assets/17195999-f517-442e-8426-73cb0496710e" /> |

### Duotones chooser

| Before | After |
|---|---|
| <img width="257" height="251" alt="Screenshot 2026-02-01 at 6 34 58 PM" src="https://github.com/user-attachments/assets/9d1fb211-2afb-4972-b89d-ccb842da31a2" /><img width="263" height="359" alt="Screenshot 2026-02-01 at 6 34 32 PM" src="https://github.com/user-attachments/assets/84c1fbd4-1ac0-4d36-b013-7e8cb8e543f6" /> | <img width="807" height="578" alt="Screenshot 2026-02-01 at 6 33 39 PM" src="https://github.com/user-attachments/assets/3f991c49-e4a6-4fa8-9cda-ba6295d17e53" /> |

## Documentation

- [x] Changes to WP defaults visible to editors should be documented in the Wiki
