### PR TITLE
DWPS-76 SMTP / Email Plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ util.sh
 # Ignore asset backups.
 /backups/assets/*
 
+# Ignore entire backups directory.
+/backups
+
 # Ignore Caddy file server config on staging
 Caddyfile
 

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "wpackagist-plugin/filebird": "^6.5",
         "wpengine/advanced-custom-fields-pro": "^6.7",
         "wpackagist-plugin/melapress-login-security": "^2.3",
-        "wpackagist-plugin/seo-by-rank-math": "^1.0"
+        "wpackagist-plugin/seo-by-rank-math": "^1.0",
+        "wpackagist-plugin/fluent-smtp": "^2.2"
     }
 }


### PR DESCRIPTION
## Description

Requires the [Fluent SMTP](https://fluentsmtp.com/) plugin for handling SMTP as an alternative to php's `sendmail` which does not work natively in the Docker PHP image.

## Motivation / Context

Part of #76 

## Testing Instructions

- In the Tugboat preview, verify that the `Fluent SMTP` plugin is added and available to be activated
- Activate the plugin and verify that it activates without errors.

## Documentation

No documentation is required _yet_, but if we like this solution, the method should be documented in the Wiki.
