### PR TITLE
DWPS-85 Explicit H1s

### DIFF
--- a/wp-content/themes/devoted/parts/page-header.html
+++ b/wp-content/themes/devoted/parts/page-header.html
@@ -2,7 +2,7 @@
 <div class="wp-block-group is-layout-constrained page-header">
     <!-- wp:group -->
     <div class="wp-block-group alignwide has-global-padding">
-        <!-- wp:post-title /-->
+        <!-- wp:post-title {"level":1} /-->
         <!-- wp:template-part {"slug":"post-meta"} /-->
     </div>
     <!-- /wp:group -->

--- a/wp-content/themes/devoted/templates/archive.html
+++ b/wp-content/themes/devoted/templates/archive.html
@@ -3,7 +3,7 @@
 <div class="wp-block-group is-layout-constrained page-header">
     <!-- wp:group -->
     <div class="wp-block-group alignwide has-global-padding">
-        <!-- wp:query-title {"type":"archive"} /-->
+        <!-- wp:query-title {"type":"archive", "level":1} /-->
         <!-- wp:term-description /-->
     </div>
     <!-- /wp:group -->

--- a/wp-content/themes/devoted/templates/category.html
+++ b/wp-content/themes/devoted/templates/category.html
@@ -3,7 +3,7 @@
 <div class="wp-block-group is-layout-constrained page-header">
     <!-- wp:group -->
     <div class="wp-block-group alignwide has-global-padding">
-        <!-- wp:query-title {"type":"archive"} /-->
+        <!-- wp:query-title {"type":"archive","level":1} /-->
         <!-- wp:term-description /-->
     </div>
     <!-- /wp:group -->

--- a/wp-content/themes/devoted/templates/search.html
+++ b/wp-content/themes/devoted/templates/search.html
@@ -3,7 +3,7 @@
 <div class="wp-block-group is-layout-constrained page-header">
 <!-- wp:group -->
     <div class="wp-block-group alignwide has-global-padding">
-        <!-- wp:query-title {"type":"search","level":2} /-->
+        <!-- wp:query-title {"type":"search","level":1} /-->
     </div>
 <!-- /wp:group -->
 </div>

--- a/wp-content/themes/devoted/templates/tag.html
+++ b/wp-content/themes/devoted/templates/tag.html
@@ -3,7 +3,7 @@
 <div class="wp-block-group is-layout-constrained page-header">
     <!-- wp:group -->
     <div class="wp-block-group alignwide has-global-padding">
-        <!-- wp:query-title {"type":"archive"} /-->
+        <!-- wp:query-title {"type":"archive","level":1} /-->
         <!-- wp:term-description /-->
     </div>
 <!-- /wp:group -->


### PR DESCRIPTION
## Description

The WP core block `post-title` generates an `<h2>` by default. For instances where we use `core/post-title` to generate a page's title on its own template, we want an `<h1>`.

- `page-header` pattern explicitly prints an `<h1>`.
- Likewise, `core/query-title` has been modified on archive templates to ensure they have `<h1>`s as well.

## Motivation / Context

Closes #85 

## Testing Instructions

1. In the Tugboat preview, open any page or post and verify the page title is an H1.
2. Check the archive templates (Search, Category, Tag) and verify the page titles are H1s.

## Documentation

- [x] No documentation updates are required.
- [x] No user guide additions are necessary.
