### PR TITLE
Upgrade to WordPress 7.0 / PHP 8.3

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -3,7 +3,7 @@ PROJECT_NAME=enter_your_project_name
 
 # Docker Images
 # Adjust versions as needed by your project.
-DOCKER_WORDPRESS_IMAGE=wordpress:6.8.3-php8.2-apache
+DOCKER_WORDPRESS_IMAGE=wordpress:7.0-php8.3-apache
 DOCKER_DB_IMAGE=mariadb:noble
 DOCKER_DB_GUI_IMAGE=phpmyadmin:latest
 

--- a/.github/workflows/deploy-do.yml
+++ b/.github/workflows/deploy-do.yml
@@ -26,5 +26,7 @@ jobs:
             git pull origin main
             docker compose down
             docker compose up -d --build
+            docker exec wordpress wp core update --allow-root
+            docker exec wordpress wp core update-db --allow-root
             docker exec wordpress composer update
             docker exec wordpress sh -c "cd /var/www/html/wp-content/themes/devoted && npm ci && npm run build"

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -43,7 +43,7 @@ services:
         # Use wp-cil to download & install a version of WordPress for Tugboat to
         # serve within the preview. First, download a wp version that matches
         # our project...
-        - wp core download --version=6.9
+        - wp core download --version=7.0
 
         # wp-cli expects a wp-config file even though Tugboat will overwrite it.
         # Copy one from our Tugboat config to run the install.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Using `docker compose` we create the following technology stack:
 | Database | [MariaDB](https://mariadb.org) | [Official MariaDB Docker Images](https://hub.docker.com/_/mariadb) |
 | Database GUI | [phpMyAdmin](https://www.phpmyadmin.net) | [Official phpMyAdmin Docker Images](https://hub.docker.com/_/phpmyadmin) |
 | Package Management | [Composer](https://getcomposer.org/) | [Composer Docker Images](https://hub.docker.com/r/composer/composer): same as official but with faster releases |
+| CLI | [WP-CLI](https://wp-cli.org/) | [Official WordPress CLI Docker Image](https://hub.docker.com/_/wordpress) (`wordpress:cli`) |
 | Testing Environtment | [Tugboat](https://www.tugboatqa.com/) | *N/A* |
 
 
@@ -80,6 +81,18 @@ variables.*
    [http://localhost:8000](http://localhost:8000) and follow the WordPress setup
    wizard the first time you run the stack.
 
+   Alternatively, complete the install without the browser using WP-CLI (bundled
+   in the image):
+
+   ```sh
+   docker exec -u www-data wordpress wp core install \
+     --url=http://localhost:8000 \
+     --title="Devoted WP Start" \
+     --admin_user=admin \
+     --admin_password=changeme \
+     --admin_email=you@example.com
+   ```
+
 Once running, the following services are available:
 
 | Service | URL |
@@ -110,8 +123,27 @@ Theme source lives in `wp-content/themes/devoted/`:
   the browser.
 - **View logs:** `docker compose logs -f wordpress`
 - **Open a shell in the container:** `docker exec -it wordpress bash`
+- **Run WP-CLI:** `docker exec -u www-data wordpress wp <command>` (see below).
 - **Stop the stack:** `docker compose down` (add `-v` to also remove the
   database and WordPress volumes for a clean slate).
+
+### WP-CLI
+
+The image bundles [WP-CLI](https://wp-cli.org/) (the `wp` binary), so core
+upgrades, plugin/theme management, database operations, and site config can all
+be run from the container instead of the browser. Run it as the `www-data` user
+so commands don't need `--allow-root` and any files WP-CLI writes keep the
+correct ownership:
+
+```sh
+docker exec -u www-data wordpress wp core version      # check WP version
+docker exec -u www-data wordpress wp plugin list       # list installed plugins
+docker exec -u www-data wordpress wp cache flush        # flush the object cache
+docker exec -u www-data wordpress wp search-replace old.example.com localhost:8000
+```
+
+For an interactive session, open a shell first
+(`docker exec -it -u www-data wordpress bash`) and run `wp ...` directly.
 
 ### Custom blocks (TypeScript)
 
@@ -177,6 +209,10 @@ Plugins are managed with [Composer](https://getcomposer.org/) via
 
 Installing the ACF Pro package requires a valid license/auth token (via
 `auth.json`, which is gitignored).
+
+Composer installs plugin files; activating them is a separate step you can do in
+the admin UI or with WP-CLI, e.g.
+`docker exec -u www-data wordpress wp plugin activate <slug>`.
 
 ### Rebuilding the containers
 

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     }
     },
     "require": {
-        "wpackagist-plugin/wp-smushit": "^3.23",
+        "wpackagist-plugin/wp-smushit": "^4.2",
         "wpackagist-plugin/filebird": "^6.5",
         "wpengine/advanced-custom-fields-pro": "^6.7",
         "wpackagist-plugin/melapress-login-security": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dc762548640a8157ad4cde3c44cd0304",
+    "content-hash": "08468adf7e7a69d8649b3d76cd99c91b",
     "packages": [
         {
             "name": "composer/installers",
@@ -226,15 +226,15 @@
         },
         {
             "name": "wpackagist-plugin/wp-smushit",
-            "version": "3.24.0",
+            "version": "4.2.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wp-smushit/",
-                "reference": "tags/3.24.0"
+                "reference": "tags/4.2.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wp-smushit.3.24.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/wp-smushit.4.2.0.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"

--- a/wordpress/Dockerfile
+++ b/wordpress/Dockerfile
@@ -1,5 +1,5 @@
 # Get the WP image to use from environment variable.
-ARG wpimage="wordpress:php8.2-apache"
+ARG wpimage="wordpress:php8.3-apache"
 
 # Get the base image.
 FROM ${wpimage}
@@ -7,6 +7,9 @@ FROM ${wpimage}
 # Install Composer from Docker image and update it.
 COPY --from=composer/composer:latest-bin /composer /usr/bin/composer
 RUN composer self-update
+
+# Install wp-cli so core upgrades/verification can run inside the container.
+COPY --from=wordpress:cli /usr/local/bin/wp /usr/local/bin/wp
 
 # Install Node.js so custom blocks (authored in TypeScript under the theme's
 # `src` directory) can be compiled with @wordpress/scripts inside the container.


### PR DESCRIPTION
Closes #94 

## Change Description

Upgrades WordPress from 6.9.4 to 7.0(.2) and PHP from 8.2 to 8.3 across local Docker, Tugboat previews, and production, and fixes the actual upgrade mechanism used in `deploy-do.yml`.

- **Phase 1** — widens the `wp-smushit` Composer constraint from `^3.23` to `^4.2` so it can resolve to a release tested against WP7 (following the repo's existing caret-off-current-version convention for plugin pins).
- **Phase 2** — bumps the WordPress/PHP Docker image tags (`.env.template`, `wordpress/Dockerfile` default arg) to `7.0-php8.3-apache`. Also discovered mid-implementation that bumping the image tag alone doesn't upgrade an already-provisioned install: the `wp_html` named volume persists core files across container recreation, and `docker-entrypoint.sh` only copies core files into an *empty* volume. `deploy-do.yml` runs the same `docker compose down && up -d --build` against production's own long-lived volume, so the same gap applies there. Fixed by adding `wp-cli` to the Dockerfile and running `wp core update && wp core update-db` as an explicit, idempotent step after build — this performs the real WordPress-native file swap and DB schema migration regardless of volume state.
- **Phase 3** — bumps `.tugboat/config.yml`'s `wp core download --version` to `7.0` so preview environments match Docker/production instead of staying pinned to 6.9.


## Verification

- `docker compose down && docker compose build --no-cache && docker compose up -d --force-recreate`, then confirm site loads, admin login works, block editor loads normally for `devoted/example` block + ACF fields, and FluentSMTP still sends a test email.

## Not Doing

- Not touching ACF Pro, FileBird, Rank Math, or Melapress — already tested against WP 7.0.2.
- Not replacing FluentSMTP (proceeding with a manual send-test instead of blocking on the vendor's own compatibility testing).
- Not bumping `theme.json`, block `apiVersion`, `@wordpress/scripts`, or `style.css`'s `Requires at least` header — already current or cosmetic-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)