### PR TITLE
GH-97: Plugin additions/adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,24 @@ Composer installs plugin files; activating them is a separate step you can do in
 the admin UI or with WP-CLI, e.g.
 `docker exec -u www-data wordpress wp plugin activate <slug>`.
 
+### Installed plugins
+
+| Plugin | Slug | Purpose | Notes |
+|---|---|---|---|
+| Yoast SEO | `wordpress-seo` | SEO metadata, sitemaps, and content analysis. | Replaces Rank Math. |
+| Duplicate Post | `duplicate-post` | Duplicate posts and pages from the admin list/editor. | |
+| Admin Menu Editor | `admin-menu-editor` | Customize and reorganize the wp-admin menu. | |
+| Converter for Media | `webp-converter-for-media` | Converts uploaded images to WebP/AVIF on the fly. | Can be removed if the client purchases Smush Pro. |
+| Complianz GDPR | `complianz-gdpr` | Cookie/consent banner and privacy policy compliance. | |
+| Google Site Kit | `google-site-kit` | Connects Google Search Console, Analytics, and other Google tools. | |
+| The Icon Block | `icon-block` | Adds an icon block with a large built-in icon library. | Distinct from the native core icon block, which is disabled in `functions.php`. |
+| Accessibility Checker | `accessibility-checker` | Scans content for accessibility issues in the editor. | |
+| Smush | `wp-smushit` | Image compression/optimization. | |
+| FileBird | `filebird` | Folder organization for the Media Library. | |
+| Advanced Custom Fields PRO | `advanced-custom-fields-pro` | Custom fields for posts, pages, and blocks. | |
+| Melapress Login Security | `melapress-login-security` | Login hardening (lockouts, 2FA, login logging). | |
+| Fluent SMTP | `fluent-smtp` | Configures outbound mail delivery via SMTP/API. | |
+
 ### Rebuilding the containers
 
 Changes to `docker-compose.yml`, the `wordpress/Dockerfile`, or the

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,14 @@
         "wpackagist-plugin/filebird": "^6.5",
         "wpengine/advanced-custom-fields-pro": "^6.7",
         "wpackagist-plugin/melapress-login-security": "^2.3",
-        "wpackagist-plugin/seo-by-rank-math": "^1.0",
-        "wpackagist-plugin/fluent-smtp": "^2.2"
+        "wpackagist-plugin/fluent-smtp": "^2.2",
+        "wpackagist-plugin/wordpress-seo": "^28.1",
+        "wpackagist-plugin/duplicate-post": "^4.7",
+        "wpackagist-plugin/admin-menu-editor": "^1.15",
+        "wpackagist-plugin/webp-converter-for-media": "^6.6",
+        "wpackagist-plugin/complianz-gdpr": "^7.5",
+        "wpackagist-plugin/google-site-kit": "^1.183",
+        "wpackagist-plugin/icon-block": "^2.0",
+        "wpackagist-plugin/accessibility-checker": "^1.47"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "08468adf7e7a69d8649b3d76cd99c91b",
+    "content-hash": "76738c30fc14bda37968b9a756f0ba8c",
     "packages": [
         {
             "name": "composer/installers",
@@ -153,6 +153,78 @@
             "time": "2024-06-24T20:46:46+00:00"
         },
         {
+            "name": "wpackagist-plugin/accessibility-checker",
+            "version": "1.47.0",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/accessibility-checker/",
+                "reference": "tags/1.47.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/accessibility-checker.1.47.0.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/accessibility-checker/"
+        },
+        {
+            "name": "wpackagist-plugin/admin-menu-editor",
+            "version": "1.15.1",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/admin-menu-editor/",
+                "reference": "tags/1.15.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/admin-menu-editor.1.15.1.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/admin-menu-editor/"
+        },
+        {
+            "name": "wpackagist-plugin/complianz-gdpr",
+            "version": "7.5.0",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/complianz-gdpr/",
+                "reference": "tags/7.5.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/complianz-gdpr.7.5.0.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/complianz-gdpr/"
+        },
+        {
+            "name": "wpackagist-plugin/duplicate-post",
+            "version": "4.7",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/duplicate-post/",
+                "reference": "tags/4.7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/duplicate-post.4.7.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/duplicate-post/"
+        },
+        {
             "name": "wpackagist-plugin/filebird",
             "version": "6.5.5",
             "source": {
@@ -189,6 +261,42 @@
             "homepage": "https://wordpress.org/plugins/fluent-smtp/"
         },
         {
+            "name": "wpackagist-plugin/google-site-kit",
+            "version": "1.183.0",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/google-site-kit/",
+                "reference": "tags/1.183.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/google-site-kit.1.183.0.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/google-site-kit/"
+        },
+        {
+            "name": "wpackagist-plugin/icon-block",
+            "version": "2.0.0",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/icon-block/",
+                "reference": "tags/2.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/icon-block.2.0.0.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/icon-block/"
+        },
+        {
             "name": "wpackagist-plugin/melapress-login-security",
             "version": "2.3.0",
             "source": {
@@ -207,22 +315,40 @@
             "homepage": "https://wordpress.org/plugins/melapress-login-security/"
         },
         {
-            "name": "wpackagist-plugin/seo-by-rank-math",
-            "version": "1.0.274.1",
+            "name": "wpackagist-plugin/webp-converter-for-media",
+            "version": "6.6.2",
             "source": {
                 "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/seo-by-rank-math/",
-                "reference": "tags/1.0.274.1"
+                "url": "https://plugins.svn.wordpress.org/webp-converter-for-media/",
+                "reference": "tags/6.6.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/seo-by-rank-math.1.0.274.1.zip"
+                "url": "https://downloads.wordpress.org/plugin/webp-converter-for-media.6.6.2.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
             },
             "type": "wordpress-plugin",
-            "homepage": "https://wordpress.org/plugins/seo-by-rank-math/"
+            "homepage": "https://wordpress.org/plugins/webp-converter-for-media/"
+        },
+        {
+            "name": "wpackagist-plugin/wordpress-seo",
+            "version": "28.1",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/wordpress-seo/",
+                "reference": "tags/28.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/wordpress-seo.28.1.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/wordpress-seo/"
         },
         {
             "name": "wpackagist-plugin/wp-smushit",

--- a/wp-content/themes/devoted/functions.php
+++ b/wp-content/themes/devoted/functions.php
@@ -59,7 +59,8 @@ add_filter( 'get_the_archive_title_prefix', '__return_false' );
 function devoted_disallow_blocks($allowed_block_types, $block_editor_context) {
 
 	$disallowed_blocks = array(
-		'core/spacer'
+		'core/spacer',
+		'core/icon'
 	);
 
 	// Get all registered blocks if $allowed_block_types is not already set.


### PR DESCRIPTION
## Change Description

Swaps Rank Math for Yoast SEO and adds the six other plugins requested for GH-97 (Duplicate Post, Admin Menu Editor, Converter for Media, Complianz GDPR, Google Site Kit, The Icon Block, Accessibility Checker), all via the existing Composer/wpackagist workflow — no new Composer repository was needed since every plugin is on wordpress.org. Disables the native `core/icon` block in `functions.php` (same mechanism already used for `core/spacer`) so it doesn't compete with The Icon Block plugin's own block in the inserter. Documents every installed plugin (added and pre-existing) in a new README table, since the ticket's "User Guide" is an external GitHub Wiki that isn't editable from this repo.

<img width="1709" height="1394" alt="image" src="https://github.com/user-attachments/assets/e2cd04c0-aa27-4ebc-9d6c-698521b6a3fd" />


## Link To Ticket

Closes https://github.com/The-Devoted/devoted-wp-start/issues/97

## Implementation Notes

- `composer.lock` was regenerated via `composer update`; diff is limited to the 8 changed packages (7 additions + Rank Math removal), no unrelated transitive dependency churn.

## Post Deploy Tasks

N/A — plugin activation remains a manual step per existing project convention (not automated by this PR).

## Open Risk / Follow-up

The ticket names an external GitHub Wiki as the "User Guide," which isn't editable from this repo. Per-plugin notes were added to `README.md` instead. **Recommend mirroring the same table to the Wiki as a manual follow-up.**

## Readiness

- [x] Verified `composer update` / `composer validate` succeed and `wp-content/plugins/` reflects the new set
- [x] Verified `functions.php` passes `php -l`
- [x] Manual: confirmed native "Icon" block no longer appears in the block inserter, while "The Icon Block" (`outermost/icon-block`) still does

## Breaking Change?

- [ ] Yes
- [x] No