### PR TITLE
Add E2E Smoke Tests to validate start is stable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ jobs:
   e2e:
     name: Playwright E2E
     runs-on: ubuntu-latest
+    env:
+      COMPOSER_AUTH_JSON: ${{ secrets.COMPOSER_AUTH_JSON }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -35,8 +37,6 @@ jobs:
       # Forked PRs don't get repo secrets, so fall back to the placeholder;
       # global-setup.ts installs the free ACF plugin when auth.json is empty.
       - name: Write auth.json
-        env:
-          COMPOSER_AUTH_JSON: ${{ secrets.COMPOSER_AUTH_JSON }}
         run: |
           if [ -n "$COMPOSER_AUTH_JSON" ]; then
             echo "$COMPOSER_AUTH_JSON" > auth.json
@@ -51,7 +51,7 @@ jobs:
       # forked PRs don't get repo secrets and keep relying on the free-ACF
       # fallback in global-setup.ts.
       - name: Install Composer-managed plugins
-        if: ${{ secrets.COMPOSER_AUTH_JSON != '' }}
+        if: ${{ env.COMPOSER_AUTH_JSON != '' }}
         run: docker exec wordpress composer update --no-interaction
 
       - name: Build the theme's custom blocks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,73 @@
+name: E2E Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: Playwright E2E
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Write .env
+        run: |
+          cat <<'EOF' > .env
+          PROJECT_NAME=devoted_wp_e2e
+          DOCKER_WORDPRESS_IMAGE=wordpress:7.0-php8.3-apache
+          DOCKER_DB_IMAGE=mariadb:noble
+          DOCKER_DB_GUI_IMAGE=phpmyadmin:latest
+          WORDPRESS_THEME_NAME=devoted
+          WORDPRESS_DB_NAME=wordpress
+          WORDPRESS_DB_HOST=db
+          WORDPRESS_DB_USER=wordpress
+          WORDPRESS_DB_PASSWORD=wordpress
+          WORDPRESS_DEBUG=true
+          MYSQL_ROOT_HOST=%
+          EOF
+
+      # Composer plugin installs need auth.json even when it stays empty;
+      # the ACF Pro / WP Engine credentials it'd otherwise hold aren't wired
+      # into CI yet (tracked in issue #101's prerequisite).
+      - name: Write placeholder auth.json
+        run: echo '{}' > auth.json
+
+      - name: Start the Docker stack
+        run: docker compose up -d --build
+
+      - name: Build the theme's custom blocks
+        run: docker exec wordpress sh -c "cd /var/www/html/wp-content/themes/devoted && npm ci && npm run build"
+
+      - name: Install e2e test dependencies
+        working-directory: tests/e2e
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: tests/e2e
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        working-directory: tests/e2e
+        run: npm test
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: tests/e2e/playwright-report/
+          retention-days: 7
+
+      - name: Docker logs (on failure)
+        if: failure()
+        run: docker compose logs
+
+      - name: Stop the Docker stack
+        if: always()
+        run: docker compose down -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,14 +32,27 @@ jobs:
           MYSQL_ROOT_HOST=%
           EOF
 
-      # Composer plugin installs need auth.json even when it stays empty;
-      # the ACF Pro / WP Engine credentials it'd otherwise hold aren't wired
-      # into CI yet (tracked in issue #101's prerequisite).
-      - name: Write placeholder auth.json
-        run: echo '{}' > auth.json
+      # Forked PRs don't get repo secrets, so fall back to the placeholder;
+      # global-setup.ts installs the free ACF plugin when auth.json is empty.
+      - name: Write auth.json
+        env:
+          COMPOSER_AUTH_JSON: ${{ secrets.COMPOSER_AUTH_JSON }}
+        run: |
+          if [ -n "$COMPOSER_AUTH_JSON" ]; then
+            echo "$COMPOSER_AUTH_JSON" > auth.json
+          else
+            echo '{}' > auth.json
+          fi
 
       - name: Start the Docker stack
         run: docker compose up -d --build
+
+      # Only runs when the secret is set (same-repo PRs, pushes to main);
+      # forked PRs don't get repo secrets and keep relying on the free-ACF
+      # fallback in global-setup.ts.
+      - name: Install Composer-managed plugins
+        if: ${{ secrets.COMPOSER_AUTH_JSON != '' }}
+        run: docker exec wordpress composer update --no-interaction
 
       - name: Build the theme's custom blocks
         run: docker exec wordpress sh -c "cd /var/www/html/wp-content/themes/devoted && npm ci && npm run build"

--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,12 @@ node_modules
 # Built from the theme's `src` directory via @wordpress/scripts (`npm run build`).
 /wp-content/themes/devoted/build/
 
+# Playwright e2e test output.
+# --------------------------
+/tests/e2e/test-results/
+/tests/e2e/playwright-report/
+/tests/e2e/.auth/
+
 # Sass.
 # --------------------------
 .sass-cache/

--- a/README.md
+++ b/README.md
@@ -194,6 +194,21 @@ includes Node.js): the workflow rebuilds the image and runs
 `npm ci && npm run build` against the theme. Because `build/` is git-ignored,
 committing a change to a block means committing the `src/` change only.
 
+### End-to-end testing
+
+[Playwright](https://playwright.dev) smoke tests live in `tests/e2e/`, a
+separate npm package from the theme. With the Docker stack running:
+
+```sh
+cd tests/e2e
+npm install       # first time only
+npm test
+```
+
+See [`tests/e2e/README.md`](tests/e2e/README.md) for scope, environment
+variables, and how this runs in CI (`.github/workflows/test.yml`, on pull
+requests and pushes to `main`).
+
 ### Managing plugins and dependencies
 
 Plugins are managed with [Composer](https://getcomposer.org/) via

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -45,6 +45,16 @@ implementation is repeatable and the suite's vocabulary matches the app's:
 - `fixtures/sitemap.ts` — `fetchSitemapUrls(indexUrl?)` walks a sitemap
   index (Yoast SEO's `/sitemap_index.xml` by default) and returns every page
   URL it lists, recursing into nested per-post-type sitemaps.
+- `fixtures/wpCli.ts` — `wp(args)`, runs a `wp` CLI command inside the
+  WordPress container (shared by `global-setup.ts` and `fixtures/wpPosts.ts`).
+- `fixtures/wpPosts.ts` — a [Playwright test fixture](https://playwright.dev/docs/test-fixtures)
+  (`test`/`expect` re-exported from here, in place of `@playwright/test`) that
+  adds a `trackPost(postId)` fixture: register any post/page a test creates
+  and it's deleted via `wp post delete --force` once the test finishes, pass
+  or fail. This is this suite's setup/teardown convention for test content —
+  specs that create posts or pages should import `test`/`expect` from
+  `fixtures/wpPosts` and track what they create, rather than leaving it
+  behind for a long-lived instance to accumulate.
 
 Locator and method names mirror Gutenberg/WordPress's own accessible names
 ("Add title", "Add default block", "Editor publish") instead of inventing
@@ -64,13 +74,6 @@ The Accessibility Checker plugin's own dashboard summary widget
 plugin, not the theme, so `accessibility.spec.ts` excludes it rather than
 failing CI on something this repo can't fix. Update the selector if the
 plugin's markup changes, or drop the exclusion once it's fixed upstream.
-
-## Known gap: sitemap crawl grows with leftover test content
-
-`editor.spec.ts` publishes pages named `e2e-test-page-<timestamp>` and
-doesn't clean them up, so repeated local runs accumulate pages that the
-sitemap crawl will also scan. Harmless (just redundant coverage), but
-worth knowing if the sitemap test gets noticeably slower over time locally.
 
 ## Known gap: forked PRs fall back to the free ACF plugin
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -17,7 +17,10 @@ Small slice, core smoke coverage only:
   theme's `devoted/example` block, publishes it, checks both render.
 - `specs/accessibility.spec.ts` — runs an [axe-core](https://www.npmjs.com/package/@axe-core/playwright)
   WCAG 2.0/2.1 A/AA scan against the front page, login page, and admin
-  dashboard, failing on any violation.
+  dashboard, failing on any violation. It also crawls every URL listed in
+  the site's sitemap (`fixtures/sitemap.ts`) and scans each one, reporting
+  every offending URL and its violations together rather than failing on
+  the first bad page.
 
 ## Page objects
 
@@ -36,6 +39,12 @@ implementation is repeatable and the suite's vocabulary matches the app's:
   a thin wrapper around `AxeBuilder` used by `accessibility.spec.ts`. The
   `exclude` param takes CSS selectors for third-party plugin markup this
   suite doesn't own (see "Known gap" below), not theme/core chrome.
+  `getAccessibilityViolations`/`summarizeAccessibilityViolations` expose the
+  same scan without asserting, for callers (the sitemap crawl) that need to
+  keep going across several pages and report everything at once.
+- `fixtures/sitemap.ts` — `fetchSitemapUrls(indexUrl?)` walks a sitemap
+  index (Yoast SEO's `/sitemap_index.xml` by default) and returns every page
+  URL it lists, recursing into nested per-post-type sitemaps.
 
 Locator and method names mirror Gutenberg/WordPress's own accessible names
 ("Add title", "Add default block", "Editor publish") instead of inventing
@@ -56,6 +65,13 @@ plugin, not the theme, so `accessibility.spec.ts` excludes it rather than
 failing CI on something this repo can't fix. Update the selector if the
 plugin's markup changes, or drop the exclusion once it's fixed upstream.
 
+## Known gap: sitemap crawl grows with leftover test content
+
+`editor.spec.ts` publishes pages named `e2e-test-page-<timestamp>` and
+doesn't clean them up, so repeated local runs accumulate pages that the
+sitemap crawl will also scan. Harmless (just redundant coverage), but
+worth knowing if the sitemap test gets noticeably slower over time locally.
+
 ## Known gap: forked PRs fall back to the free ACF plugin
 
 The theme needs ACF's `get_field()` or the site 500s. Production/local dev
@@ -74,7 +90,9 @@ assert on ACF-specific behavior, so the fallback is fine for smoke coverage
 3. `npm test`.
 
 `global-setup.ts` waits for WordPress to be ready, runs an idempotent
-`wp core install` with fixed test credentials, activates the `devoted` theme
+`wp core install` with fixed test credentials, switches permalinks to
+`/%postname%/` (a fresh install defaults to plain `?p=123` permalinks,
+under which Yoast SEO's sitemap URLs 404), activates the `devoted` theme
 and installed plugins, and ensures ACF is available.
 
 | Var | Default | Purpose |

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -40,14 +40,16 @@ under `pages/` or `components/`, not new inline locators in a spec.
 Per-plugin checks (ACF fields, Yoast/Rank Math, login-security, cookie
 consent, etc.) are out of scope for now.
 
-## Known gap: ACF is stood in, not the real dependency
+## Known gap: forked PRs fall back to the free ACF plugin
 
 The theme needs ACF's `get_field()` or the site 500s. Production/local dev
-use ACF Pro via Composer + a WP Engine license (see root README). CI doesn't
-have those credentials yet, so `global-setup.ts` falls back to installing the
-free ACF plugin when nothing providing `get_field()` is active. Wiring up the
-real Composer credentials would remove this fallback and unblock per-plugin
-specs.
+use ACF Pro via Composer + a WP Engine license (see root README). CI has
+those credentials in the `COMPOSER_AUTH_JSON` repo secret and runs
+`composer update` for same-repo PRs and pushes to `main`. Forked PRs don't
+get repo secrets, so `global-setup.ts` falls back to installing the free ACF
+plugin when nothing providing `get_field()` is active. This suite doesn't
+assert on ACF-specific behavior, so the fallback is fine for smoke coverage
+— it just blocks per-plugin specs from running against forked PRs.
 
 ## Running locally
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -15,6 +15,9 @@ Small slice, core smoke coverage only:
   dashboard loads after login.
 - `specs/editor.spec.ts` — creates a page with a core Paragraph block and the
   theme's `devoted/example` block, publishes it, checks both render.
+- `specs/accessibility.spec.ts` — runs an [axe-core](https://www.npmjs.com/package/@axe-core/playwright)
+  WCAG 2.0/2.1 A/AA scan against the front page, login page, and admin
+  dashboard, failing on any violation.
 
 ## Page objects
 
@@ -29,6 +32,10 @@ implementation is repeatable and the suite's vocabulary matches the app's:
 - `fixtures/auth.ts` — a scenario-level helper (`loginAsAdmin`) built from
   `LoginPage`, for the "log in as the standard test admin" workflow used by
   `auth.setup.ts`.
+- `fixtures/accessibility.ts` — `expectNoAccessibilityViolations(page, exclude?)`,
+  a thin wrapper around `AxeBuilder` used by `accessibility.spec.ts`. The
+  `exclude` param takes CSS selectors for third-party plugin markup this
+  suite doesn't own (see "Known gap" below), not theme/core chrome.
 
 Locator and method names mirror Gutenberg/WordPress's own accessible names
 ("Add title", "Add default block", "Editor publish") instead of inventing
@@ -39,6 +46,15 @@ under `pages/` or `components/`, not new inline locators in a spec.
 
 Per-plugin checks (ACF fields, Yoast/Rank Math, login-security, cookie
 consent, etc.) are out of scope for now.
+
+## Known gap: dashboard a11y scan excludes the Accessibility Checker widget
+
+The Accessibility Checker plugin's own dashboard summary widget
+(`#edac_dashboard_scan_summary`) renders a progressbar that axe flags
+(missing accessible name, invalid `aria-valuenow="N/A"`) — a bug in that
+plugin, not the theme, so `accessibility.spec.ts` excludes it rather than
+failing CI on something this repo can't fix. Update the selector if the
+plugin's markup changes, or drop the exclusion once it's fixed upstream.
 
 ## Known gap: forked PRs fall back to the free ACF plugin
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,80 @@
+# E2E Tests
+
+Playwright (TypeScript) smoke tests for the Devoted WordPress starter kit —
+catch environment regressions (plugin updates, WP core bumps, dependency
+changes) before they hit production. Separate npm package from
+`wp-content/themes/devoted`.
+
+## Scope
+
+Small slice, core smoke coverage only:
+
+- `specs/auth.setup.ts` — logs in as the test admin once; other specs reuse
+  that session via Playwright's `storageState`.
+- `specs/smoke.spec.ts` — front page renders for an anonymous visitor, admin
+  dashboard loads after login.
+- `specs/editor.spec.ts` — creates a page with a core Paragraph block and the
+  theme's `devoted/example` block, publishes it, checks both render.
+
+## Page objects
+
+Specs drive the site through page objects rather than raw locators, so
+implementation is repeatable and the suite's vocabulary matches the app's:
+
+- `pages/` — one class per discrete screen (`LoginPage`, `DashboardPage`,
+  `FrontEndPage`, `BlockEditorPage`). Each exposes locators and actions for
+  that screen; specs compose them and keep the `expect()` assertions.
+- `components/` — reusable pieces embedded in more than one page
+  (`AdminBar`, `PublishPanel`).
+- `fixtures/auth.ts` — a scenario-level helper (`loginAsAdmin`) built from
+  `LoginPage`, for the "log in as the standard test admin" workflow used by
+  `auth.setup.ts`.
+
+Locator and method names mirror Gutenberg/WordPress's own accessible names
+("Add title", "Add default block", "Editor publish") instead of inventing
+parallel terminology, so the code stays legible against the actual UI.
+
+Adding coverage for a new screen or component should mean adding a class
+under `pages/` or `components/`, not new inline locators in a spec.
+
+Per-plugin checks (ACF fields, Yoast/Rank Math, login-security, cookie
+consent, etc.) are out of scope for now.
+
+## Known gap: ACF is stood in, not the real dependency
+
+The theme needs ACF's `get_field()` or the site 500s. Production/local dev
+use ACF Pro via Composer + a WP Engine license (see root README). CI doesn't
+have those credentials yet, so `global-setup.ts` falls back to installing the
+free ACF plugin when nothing providing `get_field()` is active. Wiring up the
+real Composer credentials would remove this fallback and unblock per-plugin
+specs.
+
+## Running locally
+
+1. `docker compose up -d --build` from the repo root.
+2. `npm install` (first time only).
+3. `npm test`.
+
+`global-setup.ts` waits for WordPress to be ready, runs an idempotent
+`wp core install` with fixed test credentials, activates the `devoted` theme
+and installed plugins, and ensures ACF is available.
+
+| Var | Default | Purpose |
+|---|---|---|
+| `WP_BASE_URL` | `http://localhost:8000` | Site under test |
+| `WP_ADMIN_USER` | `admin` | Test admin username |
+| `WP_ADMIN_PASSWORD` | `password` | Test admin password |
+| `WP_CONTAINER_NAME` | `wordpress` | Docker container `wp exec` runs against |
+
+Other commands:
+
+- `npm run test:ui` — Playwright UI mode, for writing/debugging specs.
+- `npm run report` — open the last HTML report.
+- `npm run typecheck` — type-check specs (not run by `npm test`).
+
+## Running in CI
+
+`.github/workflows/test.yml` runs on PRs and pushes to `main`: writes a
+throwaway `.env`/`auth.json`, brings up the Docker stack, builds the theme's
+blocks, then runs `npm test` against Chromium only. On failure, uploads the
+Playwright HTML report (with traces) as a build artifact.

--- a/tests/e2e/components/AdminBar.ts
+++ b/tests/e2e/components/AdminBar.ts
@@ -1,0 +1,23 @@
+import type { Locator, Page } from '@playwright/test';
+
+/**
+ * WordPress's persistent top toolbar, shown to every logged-in user across
+ * both wp-admin and the public-facing site.
+ */
+export class AdminBar {
+  /**
+   * The bar's `navigation` landmark (accessible name "Toolbar"). Useful for
+   * scoping queries to admin-bar content, but its own box is CSS-collapsed
+   * to zero height (WP's markup relies on floated children) — don't assert
+   * `toBeVisible()` on it directly; use `howdyMenuItem` for that.
+   */
+  readonly root: Locator;
+
+  /** WP's own "Howdy, {user}" greeting — the visible, user-facing signal that a session is authenticated. */
+  readonly howdyMenuItem: Locator;
+
+  constructor(page: Page) {
+    this.root = page.getByRole('navigation', { name: 'Toolbar' });
+    this.howdyMenuItem = page.getByRole('menuitem', { name: /^Howdy,/ });
+  }
+}

--- a/tests/e2e/components/PublishPanel.ts
+++ b/tests/e2e/components/PublishPanel.ts
@@ -1,0 +1,18 @@
+import type { Locator, Page } from '@playwright/test';
+
+/**
+ * The "Editor publish" panel Gutenberg opens after the toolbar's Publish
+ * button is clicked, where the user confirms and then gets a post-publish
+ * confirmation (including the "View Page" link).
+ */
+export class PublishPanel {
+  readonly region: Locator;
+  readonly publishButton: Locator;
+  readonly viewPageLink: Locator;
+
+  constructor(page: Page) {
+    this.region = page.getByRole('region', { name: 'Editor publish' });
+    this.publishButton = this.region.getByRole('button', { name: 'Publish', exact: true });
+    this.viewPageLink = page.getByRole('link', { name: 'View Page (opens in a new tab)' });
+  }
+}

--- a/tests/e2e/constants.ts
+++ b/tests/e2e/constants.ts
@@ -1,15 +1,16 @@
-import path from 'node:path';
+import path from "node:path";
+import process from "node:process";
 
-export const BASE_URL = process.env.WP_BASE_URL ?? 'http://localhost:8000';
+export const BASE_URL = process.env.WP_BASE_URL ?? "http://localhost:8000";
 
 /**
  * Fixed test credentials matching the idempotent `wp core install` run by
  * global-setup.ts, both locally and in CI — there's no real user data here.
  */
-export const ADMIN_USER = process.env.WP_ADMIN_USER ?? 'admin';
-export const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD ?? 'password';
+export const ADMIN_USER = process.env.WP_ADMIN_USER ?? "admin";
+export const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD ?? "password";
 
-export const WP_CONTAINER_NAME = process.env.WP_CONTAINER_NAME ?? 'wordpress';
+export const WP_CONTAINER_NAME = process.env.WP_CONTAINER_NAME ?? "wordpress";
 
 /** Storage state produced by the `setup` project's login, reused by specs. */
-export const STORAGE_STATE = path.join(__dirname, '.auth', 'admin.json');
+export const STORAGE_STATE = path.join(__dirname, ".auth", "admin.json");

--- a/tests/e2e/constants.ts
+++ b/tests/e2e/constants.ts
@@ -1,0 +1,15 @@
+import path from 'node:path';
+
+export const BASE_URL = process.env.WP_BASE_URL ?? 'http://localhost:8000';
+
+/**
+ * Fixed test credentials matching the idempotent `wp core install` run by
+ * global-setup.ts, both locally and in CI — there's no real user data here.
+ */
+export const ADMIN_USER = process.env.WP_ADMIN_USER ?? 'admin';
+export const ADMIN_PASSWORD = process.env.WP_ADMIN_PASSWORD ?? 'password';
+
+export const WP_CONTAINER_NAME = process.env.WP_CONTAINER_NAME ?? 'wordpress';
+
+/** Storage state produced by the `setup` project's login, reused by specs. */
+export const STORAGE_STATE = path.join(__dirname, '.auth', 'admin.json');

--- a/tests/e2e/fixtures/accessibility.ts
+++ b/tests/e2e/fixtures/accessibility.ts
@@ -1,0 +1,29 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, type Page } from '@playwright/test';
+
+/**
+ * Runs an axe-core scan against the current page and fails the test with a
+ * readable summary (rule, impact, affected node count, help link) if any
+ * WCAG 2.0/2.1 A/AA violations are found.
+ *
+ * `exclude` takes CSS selectors for regions to skip — for third-party
+ * plugin markup this suite doesn't own (see README "Known gap" notes)
+ * rather than the theme/core chrome this suite is meant to catch
+ * regressions in.
+ */
+export async function expectNoAccessibilityViolations(page: Page, exclude: string[] = []): Promise<void> {
+  const builder = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']);
+  for (const selector of exclude) {
+    builder.exclude(selector);
+  }
+  const results = await builder.analyze();
+
+  const summary = results.violations
+    .map(
+      (violation) =>
+        `${violation.id} (${violation.impact}): ${violation.help} — ${violation.nodes.length} node(s)\n${violation.helpUrl}`,
+    )
+    .join('\n\n');
+
+  expect(results.violations, summary).toEqual([]);
+}

--- a/tests/e2e/fixtures/accessibility.ts
+++ b/tests/e2e/fixtures/accessibility.ts
@@ -1,29 +1,44 @@
 import AxeBuilder from '@axe-core/playwright';
 import { expect, type Page } from '@playwright/test';
+import type { Result } from 'axe-core';
+
+const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
 
 /**
- * Runs an axe-core scan against the current page and fails the test with a
- * readable summary (rule, impact, affected node count, help link) if any
- * WCAG 2.0/2.1 A/AA violations are found.
+ * Runs an axe-core scan against the current page and returns any WCAG
+ * 2.0/2.1 A/AA violations found, without asserting — used where a caller
+ * needs to keep going across several pages (e.g. a sitemap crawl) and
+ * report everything at the end rather than fail on the first bad page.
  *
  * `exclude` takes CSS selectors for regions to skip — for third-party
  * plugin markup this suite doesn't own (see README "Known gap" notes)
  * rather than the theme/core chrome this suite is meant to catch
  * regressions in.
  */
-export async function expectNoAccessibilityViolations(page: Page, exclude: string[] = []): Promise<void> {
-  const builder = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']);
+export async function getAccessibilityViolations(page: Page, exclude: string[] = []): Promise<Result[]> {
+  const builder = new AxeBuilder({ page }).withTags(WCAG_TAGS);
   for (const selector of exclude) {
     builder.exclude(selector);
   }
   const results = await builder.analyze();
+  return results.violations;
+}
 
-  const summary = results.violations
+/** Readable summary (rule, impact, affected node count, help link) of axe-core violations. */
+export function summarizeAccessibilityViolations(violations: Result[]): string {
+  return violations
     .map(
       (violation) =>
         `${violation.id} (${violation.impact}): ${violation.help} — ${violation.nodes.length} node(s)\n${violation.helpUrl}`,
     )
     .join('\n\n');
+}
 
-  expect(results.violations, summary).toEqual([]);
+/**
+ * Runs an axe-core scan against the current page and fails the test with a
+ * readable summary if any WCAG 2.0/2.1 A/AA violations are found.
+ */
+export async function expectNoAccessibilityViolations(page: Page, exclude: string[] = []): Promise<void> {
+  const violations = await getAccessibilityViolations(page, exclude);
+  expect(violations, summarizeAccessibilityViolations(violations)).toEqual([]);
 }

--- a/tests/e2e/fixtures/auth.ts
+++ b/tests/e2e/fixtures/auth.ts
@@ -1,0 +1,10 @@
+import type { Page } from '@playwright/test';
+import { ADMIN_PASSWORD, ADMIN_USER } from '../constants';
+import { LoginPage } from '../pages/LoginPage';
+
+/** Logs in through the standard wp-login.php form as the test admin user. */
+export async function loginAsAdmin(page: Page): Promise<void> {
+  const loginPage = new LoginPage(page);
+  await loginPage.goto();
+  await loginPage.loginAs(ADMIN_USER, ADMIN_PASSWORD);
+}

--- a/tests/e2e/fixtures/sitemap.ts
+++ b/tests/e2e/fixtures/sitemap.ts
@@ -1,0 +1,40 @@
+import { BASE_URL } from '../constants';
+
+const LOC_PATTERN = /<loc>(.*?)<\/loc>/g;
+
+/**
+ * Walks a sitemap index and returns every page URL it lists. WordPress (via
+ * Yoast SEO here) publishes one sub-sitemap per post type/taxonomy rather
+ * than listing pages directly, so entries ending in `.xml` are treated as
+ * nested sitemaps to expand; everything else is a page URL.
+ */
+export async function fetchSitemapUrls(indexUrl = `${BASE_URL}/sitemap_index.xml`): Promise<string[]> {
+  return fetchLocs(indexUrl, new Set());
+}
+
+async function fetchLocs(url: string, visited: Set<string>): Promise<string[]> {
+  if (visited.has(url)) return [];
+  visited.add(url);
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch sitemap ${url}: ${response.status} ${response.statusText}`);
+  }
+  const xml = await response.text();
+  const locs = [...xml.matchAll(LOC_PATTERN)].map((match) => decodeXmlEntities(match[1]));
+
+  const sitemaps = locs.filter((loc) => loc.endsWith('.xml'));
+  const pages = locs.filter((loc) => !loc.endsWith('.xml'));
+  const nested = await Promise.all(sitemaps.map((loc) => fetchLocs(loc, visited)));
+
+  return [...pages, ...nested.flat()];
+}
+
+function decodeXmlEntities(value: string): string {
+  return value
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'");
+}

--- a/tests/e2e/fixtures/wpCli.ts
+++ b/tests/e2e/fixtures/wpCli.ts
@@ -1,0 +1,14 @@
+import { execFileSync } from 'node:child_process';
+import { WP_CONTAINER_NAME } from '../constants';
+
+/**
+ * Runs a `wp` CLI command inside the WordPress container. Shared by
+ * `global-setup.ts` (environment bootstrap) and `fixtures/wpPosts.ts` (test
+ * asset setup/teardown) so both go through the same docker exec plumbing.
+ */
+export function wp(args: string[]): string {
+  return execFileSync('docker', ['exec', '-u', 'www-data', WP_CONTAINER_NAME, 'wp', ...args], {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+}

--- a/tests/e2e/fixtures/wpPosts.ts
+++ b/tests/e2e/fixtures/wpPosts.ts
@@ -1,0 +1,36 @@
+import { test as base } from '@playwright/test';
+import { wp } from './wpCli';
+
+type WpPostsFixture = {
+  /**
+   * Registers a post/page ID (e.g. one created through the block editor UI)
+   * for deletion once the test finishes, pass or fail.
+   */
+  trackPost(postId: number): void;
+};
+
+/**
+ * Extends the base test with automatic teardown of any WordPress post/page
+ * a test creates, so specs stop leaving behind content that piles up in a
+ * long-lived instance (and gets re-scanned by things like the sitemap a11y
+ * crawl). Following https://playwright.dev/docs/test-fixtures: the fixture
+ * hands the test a way to register created assets, then cleans them up
+ * itself after the test body runs — specs don't need their own
+ * try/finally.
+ */
+export const test = base.extend<WpPostsFixture>({
+  trackPost: async ({}, use) => {
+    const postIds: number[] = [];
+
+    await use((postId: number) => {
+      postIds.push(postId);
+    });
+
+    for (const postId of postIds) {
+      // `--force` skips trash — test posts have no reason to linger there.
+      wp(['post', 'delete', String(postId), '--force']);
+    }
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -59,6 +59,22 @@ async function ensureWordPressInstalled(): Promise<void> {
   );
 }
 
+function hasPrettyPermalinks(): boolean {
+  return wp(['option', 'get', 'permalink_structure']).trim().length > 0;
+}
+
+/**
+ * A fresh `wp core install` defaults to plain `?p=123` permalinks, under
+ * which Yoast SEO's pretty sitemap URLs (`/post-sitemap.xml`, etc.) 404 —
+ * only their `?sitemap=` query-var form resolves. Pretty permalinks are
+ * also what real sites run, so this fixes the environment rather than
+ * teaching the sitemap fixture to route around plain permalinks.
+ */
+function ensurePrettyPermalinks(): void {
+  if (hasPrettyPermalinks()) return;
+  wp(['rewrite', 'structure', '/%postname%/', '--hard']);
+}
+
 function hasActiveAcf(): boolean {
   const active = wp(['plugin', 'list', '--status=active', '--field=name']);
   return active
@@ -83,6 +99,7 @@ function ensureAcfAvailable(): void {
 
 export default async function globalSetup(): Promise<void> {
   await ensureWordPressInstalled();
+  ensurePrettyPermalinks();
 
   wp(['theme', 'activate', 'devoted']);
   wp(['plugin', 'activate', '--all']);

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -69,12 +69,12 @@ function hasActiveAcf(): boolean {
 
 /**
  * The theme's patterns call ACF's `get_field()`, so without ACF active the
- * site 500s outright. Production and local dev use ACF Pro via Composer + a
- * WP Engine license (see the README); CI doesn't have those credentials
- * wired up yet (tracked in issue #101's prerequisite), so fall back to the
- * free version from wordpress.org just so the site is up for these smoke
- * tests. This suite doesn't assert on ACF-specific behavior — see the specs
- * README — it just needs *a* working site.
+ * site 500s outright. Production, local dev, and same-repo CI runs use ACF
+ * Pro via Composer + a WP Engine license (see the README); forked PRs don't
+ * get repo secrets, so fall back to the free version from wordpress.org just
+ * so the site is up for these smoke tests. This suite doesn't assert on
+ * ACF-specific behavior — see the specs README — it just needs *a* working
+ * site.
  */
 function ensureAcfAvailable(): void {
   if (hasActiveAcf()) return;

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,0 +1,90 @@
+import { execFileSync } from 'node:child_process';
+import { ADMIN_PASSWORD, ADMIN_USER, BASE_URL, WP_CONTAINER_NAME } from './constants';
+
+const MAX_WAIT_MS = 60_000;
+const POLL_INTERVAL_MS = 2_000;
+
+function wp(args: string[]): string {
+  return execFileSync('docker', ['exec', '-u', 'www-data', WP_CONTAINER_NAME, 'wp', ...args], {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+}
+
+function isInstalled(): boolean {
+  try {
+    wp(['core', 'is-installed']);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Installs WordPress with fixed test credentials, retrying until it succeeds.
+ * On a first boot the WordPress container can answer `wp` commands before
+ * MariaDB has finished initializing, so `wp core install` (and even `wp core
+ * is-installed`) can fail transiently — this just keeps trying rather than
+ * probing readiness a separate way.
+ */
+async function ensureWordPressInstalled(): Promise<void> {
+  const deadline = Date.now() + MAX_WAIT_MS;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    if (isInstalled()) return;
+
+    try {
+      const { origin } = new URL(BASE_URL);
+      wp([
+        'core',
+        'install',
+        `--url=${origin}`,
+        '--title=Devoted WP Start',
+        `--admin_user=${ADMIN_USER}`,
+        `--admin_password=${ADMIN_PASSWORD}`,
+        '--admin_email=e2e@example.com',
+        '--skip-email',
+      ]);
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    }
+  }
+
+  throw new Error(
+    `Timed out after ${MAX_WAIT_MS}ms waiting for WordPress to install at ${BASE_URL}. ` +
+      `Is the Docker stack running (\`docker compose up -d --build\`)? Last error: ${lastError}`
+  );
+}
+
+function hasActiveAcf(): boolean {
+  const active = wp(['plugin', 'list', '--status=active', '--field=name']);
+  return active
+    .split('\n')
+    .map((name) => name.trim())
+    .some((name) => name.startsWith('advanced-custom-fields'));
+}
+
+/**
+ * The theme's patterns call ACF's `get_field()`, so without ACF active the
+ * site 500s outright. Production and local dev use ACF Pro via Composer + a
+ * WP Engine license (see the README); CI doesn't have those credentials
+ * wired up yet (tracked in issue #101's prerequisite), so fall back to the
+ * free version from wordpress.org just so the site is up for these smoke
+ * tests. This suite doesn't assert on ACF-specific behavior — see the specs
+ * README — it just needs *a* working site.
+ */
+function ensureAcfAvailable(): void {
+  if (hasActiveAcf()) return;
+  wp(['plugin', 'install', 'advanced-custom-fields', '--activate']);
+}
+
+export default async function globalSetup(): Promise<void> {
+  await ensureWordPressInstalled();
+
+  wp(['theme', 'activate', 'devoted']);
+  wp(['plugin', 'activate', '--all']);
+  ensureAcfAvailable();
+}

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,15 +1,8 @@
-import { execFileSync } from 'node:child_process';
-import { ADMIN_PASSWORD, ADMIN_USER, BASE_URL, WP_CONTAINER_NAME } from './constants';
+import { ADMIN_PASSWORD, ADMIN_USER, BASE_URL } from './constants';
+import { wp } from './fixtures/wpCli';
 
 const MAX_WAIT_MS = 60_000;
 const POLL_INTERVAL_MS = 2_000;
-
-function wp(args: string[]): string {
-  return execFileSync('docker', ['exec', '-u', 'www-data', WP_CONTAINER_NAME, 'wp', ...args], {
-    encoding: 'utf-8',
-    stdio: ['ignore', 'pipe', 'ignore'],
-  });
-}
 
 function isInstalled(): boolean {
   try {

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -1,0 +1,114 @@
+{
+  "name": "devoted-wp-start-e2e",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "devoted-wp-start-e2e",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@playwright/test": "^1.55.0",
+        "@types/node": "^22.0.0",
+        "typescript": "^5.7.0"
+      },
+      "engines": {
+        "node": "22"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -8,12 +8,26 @@
       "name": "devoted-wp-start-e2e",
       "version": "0.1.0",
       "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
         "@playwright/test": "^1.55.0",
         "@types/node": "^22.0.0",
         "typescript": "^5.7.0"
       },
       "engines": {
         "node": "22"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@playwright/test": {
@@ -40,6 +54,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/fsevents": {

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "devoted-wp-start-e2e",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Playwright end-to-end smoke tests for the Devoted WordPress starter kit.",
+  "engines": {
+    "node": "22"
+  },
+  "scripts": {
+    "test": "playwright test",
+    "test:ui": "playwright test --ui",
+    "report": "playwright show-report",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.55.0",
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -13,6 +13,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@playwright/test": "^1.55.0",
     "@types/node": "^22.0.0",
     "typescript": "^5.7.0"

--- a/tests/e2e/pages/BlockEditorPage.ts
+++ b/tests/e2e/pages/BlockEditorPage.ts
@@ -76,6 +76,20 @@ export class BlockEditorPage {
     await expect(this.page.getByText('is now live.')).toBeVisible({ timeout: 15_000 });
   }
 
+  /**
+   * The post/page ID, read back from the `post` query param Gutenberg
+   * rewrites the URL to (`post-new.php` → `post.php?post=<id>`) once
+   * publishing completes. Used by specs to hand the ID to the `wpPosts`
+   * fixture for teardown.
+   */
+  postId(): number {
+    const id = new URL(this.page.url()).searchParams.get('post');
+    if (!id) {
+      throw new Error(`Could not read post ID from editor URL: ${this.page.url()}`);
+    }
+    return Number(id);
+  }
+
   /** Opens the published post/page in a new tab via the post-publish panel's "View Page" link. */
   async viewPublishedPage(): Promise<FrontEndPage> {
     const [popup] = await Promise.all([this.page.waitForEvent('popup'), this.publishPanel.viewPageLink.click()]);

--- a/tests/e2e/pages/BlockEditorPage.ts
+++ b/tests/e2e/pages/BlockEditorPage.ts
@@ -1,0 +1,85 @@
+import { expect, type FrameLocator, type Locator, type Page } from '@playwright/test';
+import { PublishPanel } from '../components/PublishPanel';
+import { FrontEndPage } from './FrontEndPage';
+
+type PostType = 'page' | 'post';
+
+/**
+ * Gutenberg's block editor (`post-new.php`). Locator and method names mirror
+ * Gutenberg's own accessible names ("Add title", "Add default block", the
+ * slash inserter) so the suite's vocabulary matches what a reader would see
+ * in the UI, rather than inventing parallel terminology.
+ */
+export class BlockEditorPage {
+  /**
+   * The editor renders its content (title + blocks) inside an iframe,
+   * titled "Editor canvas" — that `title` attribute is what supplies the
+   * iframe's accessible name, unlike its `name` attribute (a JS-targeting
+   * detail, not an accessibility one).
+   */
+  readonly canvas: FrameLocator;
+  readonly titleField: Locator;
+  readonly addDefaultBlockButton: Locator;
+  readonly publishButton: Locator;
+  readonly publishPanel: PublishPanel;
+
+  constructor(private readonly page: Page) {
+    this.canvas = page.frameLocator('iframe[title="Editor canvas"]');
+    this.titleField = this.canvas.getByRole('textbox', { name: 'Add title' });
+    this.addDefaultBlockButton = this.canvas.getByRole('button', { name: 'Add default block' });
+    this.publishButton = page.getByRole('button', { name: 'Publish', exact: true });
+    this.publishPanel = new PublishPanel(page);
+  }
+
+  async goto(postType: PostType = 'page'): Promise<void> {
+    await this.page.goto(`/wp-admin/post-new.php?post_type=${postType}`);
+    await this.dismissWelcomeGuide();
+  }
+
+  /** Dismisses the "Welcome to the block editor" tips dialog if it appears. */
+  async dismissWelcomeGuide(): Promise<void> {
+    const closeButton = this.page.getByRole('button', { name: 'Close' });
+    if (await closeButton.isVisible().catch(() => false)) {
+      await closeButton.click();
+    }
+  }
+
+  async setTitle(title: string): Promise<void> {
+    await this.titleField.fill(title);
+  }
+
+  async addParagraph(text: string): Promise<void> {
+    await this.addDefaultBlockButton.click();
+    await this.page.keyboard.type(text);
+  }
+
+  /**
+   * Inserts a block by name via the slash inserter — more reliable under
+   * Playwright than the sidebar Block Library, which doesn't reliably hand
+   * focus to the freshly inserted block. Leaves focus inside the new block,
+   * ready for `typeInBlock`.
+   */
+  async insertBlockViaSlashInserter(blockName: string): Promise<void> {
+    await this.page.keyboard.press('Enter');
+    await this.page.keyboard.type(`/${blockName}`);
+    await expect(this.canvas.getByRole('option', { name: blockName })).toHaveAttribute('aria-selected', 'true');
+    await this.page.keyboard.press('Enter');
+  }
+
+  async typeInBlock(text: string): Promise<void> {
+    await this.page.keyboard.type(text);
+  }
+
+  async publish(): Promise<void> {
+    await this.publishButton.click();
+    await this.publishPanel.publishButton.click();
+    await expect(this.page.getByText('is now live.')).toBeVisible({ timeout: 15_000 });
+  }
+
+  /** Opens the published post/page in a new tab via the post-publish panel's "View Page" link. */
+  async viewPublishedPage(): Promise<FrontEndPage> {
+    const [popup] = await Promise.all([this.page.waitForEvent('popup'), this.publishPanel.viewPageLink.click()]);
+    await popup.waitForLoadState();
+    return new FrontEndPage(popup);
+  }
+}

--- a/tests/e2e/pages/DashboardPage.ts
+++ b/tests/e2e/pages/DashboardPage.ts
@@ -1,0 +1,17 @@
+import type { Locator, Page } from '@playwright/test';
+import { AdminBar } from '../components/AdminBar';
+
+/** The wp-admin Dashboard (`/wp-admin/`), the landing screen after login. */
+export class DashboardPage {
+  readonly adminBar: AdminBar;
+  readonly heading: Locator;
+
+  constructor(private readonly page: Page) {
+    this.adminBar = new AdminBar(page);
+    this.heading = page.getByRole('heading', { level: 1 });
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto('/wp-admin/');
+  }
+}

--- a/tests/e2e/pages/DashboardPage.ts
+++ b/tests/e2e/pages/DashboardPage.ts
@@ -8,7 +8,7 @@ export class DashboardPage {
 
   constructor(private readonly page: Page) {
     this.adminBar = new AdminBar(page);
-    this.heading = page.getByRole('heading', { level: 1 });
+    this.heading = page.getByRole('heading', { level: 1 }).first();
   }
 
   async goto(): Promise<void> {

--- a/tests/e2e/pages/FrontEndPage.ts
+++ b/tests/e2e/pages/FrontEndPage.ts
@@ -1,0 +1,22 @@
+import type { Locator, Page } from '@playwright/test';
+
+/**
+ * The public-facing, rendered site — what an anonymous visitor sees, and
+ * also what the block editor's "View Page" popup opens. As opposed to
+ * wp-admin, which has its own page objects.
+ */
+export class FrontEndPage {
+  readonly body: Locator;
+
+  constructor(private readonly page: Page) {
+    this.body = page.locator('body');
+  }
+
+  async goto(path = '/') {
+    return this.page.goto(path);
+  }
+
+  getByText(text: string | RegExp): Locator {
+    return this.page.getByText(text);
+  }
+}

--- a/tests/e2e/pages/LoginPage.ts
+++ b/tests/e2e/pages/LoginPage.ts
@@ -1,0 +1,28 @@
+import type { Locator, Page } from '@playwright/test';
+
+/** The standard WordPress login screen at `wp-login.php`. */
+export class LoginPage {
+  readonly usernameField: Locator;
+  readonly passwordField: Locator;
+  readonly submitButton: Locator;
+
+  constructor(private readonly page: Page) {
+    this.usernameField = page.getByLabel('Username or Email Address');
+    // getByLabel('Password') would also match the "Show password" toggle
+    // button (its accessible name contains "password"); role + name scopes
+    // this to the textbox itself.
+    this.passwordField = page.getByRole('textbox', { name: 'Password' });
+    this.submitButton = page.getByRole('button', { name: 'Log In' });
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto('/wp-login.php');
+  }
+
+  async loginAs(username: string, password: string): Promise<void> {
+    await this.usernameField.fill(username);
+    await this.passwordField.fill(password);
+    await this.submitButton.click();
+    await this.page.waitForURL('**/wp-admin/**');
+  }
+}

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from '@playwright/test';
+import { BASE_URL, STORAGE_STATE } from './constants';
+
+export default defineConfig({
+  testDir: './specs',
+  outputDir: './test-results',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [['html', { open: 'never' }], ['list']] : 'list',
+  globalSetup: require.resolve('./global-setup'),
+  timeout: 30_000,
+  use: {
+    baseURL: BASE_URL,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'setup',
+      testMatch: /.*\.setup\.ts/,
+    },
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'], storageState: STORAGE_STATE },
+      dependencies: ['setup'],
+    },
+  ],
+});

--- a/tests/e2e/specs/accessibility.spec.ts
+++ b/tests/e2e/specs/accessibility.spec.ts
@@ -1,0 +1,35 @@
+import { test } from '@playwright/test';
+import { expectNoAccessibilityViolations } from '../fixtures/accessibility';
+import { DashboardPage } from '../pages/DashboardPage';
+import { FrontEndPage } from '../pages/FrontEndPage';
+import { LoginPage } from '../pages/LoginPage';
+
+test.describe('anonymous visitor', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('front page has no automatically detectable accessibility violations', async ({ page }) => {
+    const frontEnd = new FrontEndPage(page);
+    await frontEnd.goto('/');
+
+    await expectNoAccessibilityViolations(page);
+  });
+
+  test('login page has no automatically detectable accessibility violations', async ({ page }) => {
+    const loginPage = new LoginPage(page);
+    await loginPage.goto();
+
+    await expectNoAccessibilityViolations(page);
+  });
+});
+
+test.describe('authenticated admin', () => {
+  test('dashboard has no automatically detectable accessibility violations', async ({ page }) => {
+    const dashboard = new DashboardPage(page);
+    await dashboard.goto();
+
+    // The Accessibility Checker plugin's own dashboard widget renders a
+    // progressbar axe flags (missing accessible name, invalid
+    // aria-valuenow) — a third-party plugin issue, not this repo's to fix.
+    await expectNoAccessibilityViolations(page, ['#edac_dashboard_scan_summary']);
+  });
+});

--- a/tests/e2e/specs/accessibility.spec.ts
+++ b/tests/e2e/specs/accessibility.spec.ts
@@ -1,5 +1,10 @@
-import { test } from '@playwright/test';
-import { expectNoAccessibilityViolations } from '../fixtures/accessibility';
+import { expect, test } from '@playwright/test';
+import {
+  expectNoAccessibilityViolations,
+  getAccessibilityViolations,
+  summarizeAccessibilityViolations,
+} from '../fixtures/accessibility';
+import { fetchSitemapUrls } from '../fixtures/sitemap';
 import { DashboardPage } from '../pages/DashboardPage';
 import { FrontEndPage } from '../pages/FrontEndPage';
 import { LoginPage } from '../pages/LoginPage';
@@ -19,6 +24,38 @@ test.describe('anonymous visitor', () => {
     await loginPage.goto();
 
     await expectNoAccessibilityViolations(page);
+  });
+});
+
+test.describe('sitemap pages', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('every page linked from the sitemap has no automatically detectable accessibility violations', async ({
+    page,
+  }) => {
+    const urls = await fetchSitemapUrls();
+    test.skip(urls.length === 0, 'Sitemap returned no page URLs to check');
+
+    // Scanning N pages takes longer than a single-page test — scale the
+    // timeout with the sitemap size instead of a fixed budget that starts
+    // flaking as the site grows content.
+    test.setTimeout(urls.length * 10_000 + 30_000);
+
+    const violationSummaries = new Map<string, string>();
+
+    for (const url of urls) {
+      await test.step(url, async () => {
+        await page.goto(url);
+        const violations = await getAccessibilityViolations(page);
+        if (violations.length > 0) {
+          violationSummaries.set(url, summarizeAccessibilityViolations(violations));
+        }
+      });
+    }
+
+    const report = [...violationSummaries.entries()].map(([url, summary]) => `${url}\n${summary}`).join('\n\n---\n\n');
+
+    expect(violationSummaries.size, report).toBe(0);
   });
 });
 

--- a/tests/e2e/specs/auth.setup.ts
+++ b/tests/e2e/specs/auth.setup.ts
@@ -1,0 +1,17 @@
+import { expect, test as setup } from '@playwright/test';
+import { AdminBar } from '../components/AdminBar';
+import { STORAGE_STATE } from '../constants';
+import { loginAsAdmin } from '../fixtures/auth';
+
+/**
+ * Runs once before the `chromium` project (see the `setup` project's
+ * `dependencies` in playwright.config.ts). Logging in here — instead of in
+ * every spec — both verifies admin login works and produces a storageState
+ * file the rest of the suite reuses, so specs skip repeating the login flow.
+ */
+setup('authenticate as admin', async ({ page }) => {
+  await loginAsAdmin(page);
+  await expect(new AdminBar(page).howdyMenuItem).toBeVisible();
+
+  await page.context().storageState({ path: STORAGE_STATE });
+});

--- a/tests/e2e/specs/editor.spec.ts
+++ b/tests/e2e/specs/editor.spec.ts
@@ -1,7 +1,7 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from '../fixtures/wpPosts';
 import { BlockEditorPage } from '../pages/BlockEditorPage';
 
-test('editor: create a page with a core block and the custom example block', async ({ page }) => {
+test('editor: create a page with a core block and the custom example block', async ({ page, trackPost }) => {
   const pageTitle = `E2E Test Page ${Date.now()}`;
   const paragraphText = 'This paragraph was written by the Playwright e2e suite.';
   const exampleMessage = 'Example block message from the e2e suite';
@@ -19,6 +19,7 @@ test('editor: create a page with a core block and the custom example block', asy
   await editor.typeInBlock(exampleMessage);
 
   await editor.publish();
+  trackPost(editor.postId());
   const publishedPage = await editor.viewPublishedPage();
 
   await expect(publishedPage.getByText(paragraphText)).toBeVisible();

--- a/tests/e2e/specs/editor.spec.ts
+++ b/tests/e2e/specs/editor.spec.ts
@@ -22,5 +22,5 @@ test('editor: create a page with a core block and the custom example block', asy
   const publishedPage = await editor.viewPublishedPage();
 
   await expect(publishedPage.getByText(paragraphText)).toBeVisible();
-  await expect(publishedPage.getByText(`${exampleMessage} lmao`)).toBeVisible();
+  await expect(publishedPage.getByText(exampleMessage)).toBeVisible();
 });

--- a/tests/e2e/specs/editor.spec.ts
+++ b/tests/e2e/specs/editor.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@playwright/test';
+import { BlockEditorPage } from '../pages/BlockEditorPage';
+
+test('editor: create a page with a core block and the custom example block', async ({ page }) => {
+  const pageTitle = `E2E Test Page ${Date.now()}`;
+  const paragraphText = 'This paragraph was written by the Playwright e2e suite.';
+  const exampleMessage = 'Example block message from the e2e suite';
+
+  const editor = new BlockEditorPage(page);
+  await editor.goto('page');
+
+  await editor.setTitle(pageTitle);
+
+  // Add a core Paragraph block.
+  await editor.addParagraph(paragraphText);
+
+  // Add the theme's custom block.
+  await editor.insertBlockViaSlashInserter('Example (TypeScript)');
+  await editor.typeInBlock(exampleMessage);
+
+  await editor.publish();
+  const publishedPage = await editor.viewPublishedPage();
+
+  await expect(publishedPage.getByText(paragraphText)).toBeVisible();
+  await expect(publishedPage.getByText(`${exampleMessage} lmao`)).toBeVisible();
+});

--- a/tests/e2e/specs/smoke.spec.ts
+++ b/tests/e2e/specs/smoke.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@playwright/test';
+import { DashboardPage } from '../pages/DashboardPage';
+import { FrontEndPage } from '../pages/FrontEndPage';
+
+test.describe('anonymous visitor', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('front page renders without a fatal error', async ({ page }) => {
+    const frontEnd = new FrontEndPage(page);
+    const response = await frontEnd.goto('/');
+
+    expect(response?.status(), 'front page should not error').toBeLessThan(400);
+    await expect(frontEnd.body).not.toContainText('Fatal error');
+    await expect(page).toHaveTitle(/.+/);
+  });
+});
+
+test.describe('authenticated admin', () => {
+  test('admin login succeeded and the dashboard loads', async ({ page }) => {
+    const dashboard = new DashboardPage(page);
+    await dashboard.goto();
+
+    await expect(page).toHaveURL(/\/wp-admin\/?$/);
+    await expect(dashboard.adminBar.howdyMenuItem).toBeVisible();
+    await expect(dashboard.heading).toHaveText('Dashboard');
+  });
+});

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/wp-content/themes/devoted/src/example/edit.tsx
+++ b/wp-content/themes/devoted/src/example/edit.tsx
@@ -21,7 +21,6 @@ export default function Edit({ attributes, setAttributes }: EditProps) {
 
   return (
     <div>
-      hello?
       <RichText
         {...blockProps}
         tagName="p"

--- a/wp-content/themes/devoted/src/example/save.tsx
+++ b/wp-content/themes/devoted/src/example/save.tsx
@@ -20,7 +20,7 @@ export default function save( { attributes }: SaveProps ) {
 		<RichText.Content
 			{ ...blockProps }
 			tagName="p"
-			value={ `${attributes.message} lmao` }
+			value={ `${attributes.message}` }
 		/>
 	);
 }


### PR DESCRIPTION
## Description

Adds a Playwright (TypeScript) e2e smoke suite for the starter theme, wires it into CI, and gives CI access to the real ACF Pro credentials so it exercises the same plugin production/local dev use.

- `specs/auth.setup.ts` logs in as the test admin once; other specs reuse the session via `storageState`.
- `specs/smoke.spec.ts` checks the front page renders anonymously and the admin dashboard loads after login.
- `specs/editor.spec.ts` creates a page with a core Paragraph block and the theme's `devoted/example` block, publishes it, and checks both render.
- `.github/workflows/test.yml` runs the suite on PRs and pushes to `main`.
- CI now installs the real ACF Pro plugin via Composer (using the new `COMPOSER_AUTH_JSON` repo secret) instead of always falling back to the free version. Forked PRs don't get repo secrets, so they still fall back to the free plugin.

See `tests/e2e/README.md` for full scope, structure, and the remaining known gap (forked PRs and free ACF).

## Motivation / Context

Catch environment regressions (plugin updates, WP core bumps, dependency changes) before they hit production, with core smoke coverage.

## What Was Tested

Full suite run locally against the Docker stack (`npm test` in `tests/e2e`), and the updated CI workflow run against this branch.

## Testing Instructions

1. `docker compose up -d --build` from the repo root.
2. `cd tests/e2e && npm install && npm test`.

## Documentation

- [x] The following documentation updates have been made: `tests/e2e/README.md`.


## Follow-up: build/deploy consolidation

This e2e suite runs against `docker-compose.yml`, but PR preview environments still run on Tugboat's separate, non-Compose build path (own WP install, prod DB/uploads scp'd in) — so a green e2e run here doesn't validate what reviewers actually see in a preview. Consolidating everything (local, CI, previews, prod) onto a single `docker-compose.yml` is tracked separately in #103.

Shipping this suite as-is now (rather than folding in that deployment expansion first) trades broader environment parity for faster regression coverage: we get CI protection against plugin/core/dependency breakage immediately, at the cost of e2e results not covering the actual preview build path until #103 lands.
